### PR TITLE
fix loctool version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -29,6 +29,6 @@
         "ilib-loctool-webos-json-resource": "^1.2.0",
         "ilib-loctool-webos-qml": "^1.1.0",
         "ilib-loctool-webos-ts-resource": "^1.2.0",
-        "loctool": "^2.7.1"
+        "loctool": "2.7.1"
     }
 }


### PR DESCRIPTION
[Hof Fix]
The latest version of loctool breaks webOS build.
I wrote a version with caret(^) expression. But the latest of publishing version (I assume 2.8.1) of loctool makes an error during a build. So As a hotfix. I've fixed loctool version to {{2.7.1}} which I verify on webOS. and I'll figure out and fix the root cause.

CCC ticket: https://jira2.lgsvl.com/browse/PLAT-112140