### PR TITLE
Updated fixed loctool and plugins version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "8"
+  - "10"
+  - "12"
+install:
+  - rm -rf node_modules
+  - npm install
+  - export PATH=$PWD/node_modules/.bin:$PATH
+branches:
+  only:
+    - master
+dist: trusty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.2.0
+* Updated fixed loctool and plugins version
+~~~
+	"ilib-loctool-webos-appinfo-json": "1.2.2",
+	"ilib-loctool-webos-c": "1.0.1",
+	"ilib-loctool-webos-cpp": "1.0.1",
+	"ilib-loctool-webos-javascript": "1.3.0",
+	"ilib-loctool-webos-json-resource": "1.3.2",
+	"ilib-loctool-webos-qml": "1.1.1",
+	"ilib-loctool-webos-ts-resource": "1.2.1",
+	"loctool": "2.10.0"
+~~~
+
 ## 1.0.0
 * Release v1.0.0 for webOS OSE
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -18,17 +18,18 @@
     "homepage": "https://github.com/iLib-js/ilib-loctool-webos-dist#readme",
     "keywords": [
         "localization",
-        "webos",
-        "translation"
+        "globalization",
+        "translation",
+        "webOS"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "^1.2.1",
-        "ilib-loctool-webos-c": "^1.0.0",
-        "ilib-loctool-webos-cpp": "^1.0.0",
-        "ilib-loctool-webos-javascript": "^1.2.0",
-        "ilib-loctool-webos-json-resource": "^1.2.0",
-        "ilib-loctool-webos-qml": "^1.1.0",
-        "ilib-loctool-webos-ts-resource": "^1.2.0",
-        "loctool": "2.7.1"
+        "ilib-loctool-webos-appinfo-json": "1.2.2",
+        "ilib-loctool-webos-c": "1.0.1",
+        "ilib-loctool-webos-cpp": "1.0.1",
+        "ilib-loctool-webos-javascript": "1.3.0",
+        "ilib-loctool-webos-json-resource": "1.3.2",
+        "ilib-loctool-webos-qml": "1.1.1",
+        "ilib-loctool-webos-ts-resource": "1.2.1",
+        "loctool": "2.10.0"
     }
 }


### PR DESCRIPTION
* Updated fixed loctool and plugins version
```
"ilib-loctool-webos-appinfo-json": "1.2.2",
"ilib-loctool-webos-c": "1.0.1",
"ilib-loctool-webos-cpp": "1.0.1",
"ilib-loctool-webos-javascript": "1.3.0",
"ilib-loctool-webos-json-resource": "1.3.2",
"ilib-loctool-webos-qml": "1.1.1",
"ilib-loctool-webos-ts-resource": "1.2.1",
"loctool": "2.10.0"
```
* Added `.travis.yml` file to check `npm install`

CCC ticket: https://jira2.lgsvl.com/browse/PLAT-125078
