### PR TITLE
Updated fixed loctool and plugins version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,35 @@
+## 1.2.2
+* Updated fixed plugins version
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.2.5",
+    "ilib-loctool-webos-c": "1.1.0",
+    "ilib-loctool-webos-cpp": "1.1.0",
+    "ilib-loctool-webos-javascript": "1.4.0",
+    "ilib-loctool-webos-json-resource": "1.3.4",
+    "ilib-loctool-webos-qml": "1.2.0",
+    "ilib-loctool-webos-ts-resource": "1.2.3",
+    "loctool": "2.10.2"
+~~~
+
 ## 1.2.1
 * Updated fixed plugins version
 ~~~
-	"ilib-loctool-webos-appinfo-json": "1.2.4",
-	"ilib-loctool-webos-json-resource": "1.3.3",
-	"ilib-loctool-webos-ts-resource": "1.2.2"
+    "ilib-loctool-webos-appinfo-json": "1.2.4",
+    "ilib-loctool-webos-json-resource": "1.3.3",
+    "ilib-loctool-webos-ts-resource": "1.2.2"
 ~~~
 
 ## 1.2.0
 * Updated fixed loctool and plugins version
 ~~~
-	"ilib-loctool-webos-appinfo-json": "1.2.2",
-	"ilib-loctool-webos-c": "1.0.1",
-	"ilib-loctool-webos-cpp": "1.0.1",
-	"ilib-loctool-webos-javascript": "1.3.0",
-	"ilib-loctool-webos-json-resource": "1.3.2",
-	"ilib-loctool-webos-qml": "1.1.1",
-	"ilib-loctool-webos-ts-resource": "1.2.1",
-	"loctool": "2.10.0"
+    "ilib-loctool-webos-appinfo-json": "1.2.2",
+    "ilib-loctool-webos-c": "1.0.1",
+    "ilib-loctool-webos-cpp": "1.0.1",
+    "ilib-loctool-webos-javascript": "1.3.0",
+    "ilib-loctool-webos-json-resource": "1.3.2",
+    "ilib-loctool-webos-qml": "1.1.1",
+    "ilib-loctool-webos-ts-resource": "1.2.1",
+    "loctool": "2.10.0"
 ~~~
 
 ## 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.2.1",
+    "version": "1.2.2",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -23,13 +23,13 @@
         "webOS"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.2.4",
-        "ilib-loctool-webos-c": "1.0.1",
-        "ilib-loctool-webos-cpp": "1.0.1",
-        "ilib-loctool-webos-javascript": "1.3.0",
-        "ilib-loctool-webos-json-resource": "1.3.3",
-        "ilib-loctool-webos-qml": "1.1.1",
-        "ilib-loctool-webos-ts-resource": "1.2.2",
-        "loctool": "2.10.0"
+        "ilib-loctool-webos-appinfo-json": "1.2.5",
+        "ilib-loctool-webos-c": "1.1.0",
+        "ilib-loctool-webos-cpp": "1.1.0",
+        "ilib-loctool-webos-javascript": "1.4.0",
+        "ilib-loctool-webos-json-resource": "1.3.4",
+        "ilib-loctool-webos-qml": "1.2.0",
+        "ilib-loctool-webos-ts-resource": "1.2.3",
+        "loctool": "2.10.2"
     }
 }


### PR DESCRIPTION
* Updated fixed loctool and plugins version
  * Plugin version have been updated due to dependent module versions are updated
* Changed Tab to space in a file (Changelog.md)

Main changes: 
* Loctool version has been updated to `2.10.2`  which includes https://github.com/iLib-js/loctool/pull/135
* parsing plugins have a new feature to remove commented lines before starting the parsing process.