### PR TITLE
Updated fixed loctool and plugins version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.2.3
+* Updated fixed loctool and plugins version
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.2.6",
+    "ilib-loctool-webos-c": "1.1.1",
+    "ilib-loctool-webos-cpp": "1.1.1",
+    "ilib-loctool-webos-javascript": "1.4.1",
+    "ilib-loctool-webos-json-resource": "1.3.5",
+    "ilib-loctool-webos-qml": "1.3.0",
+    "ilib-loctool-webos-ts-resource": "1.2.4",
+    "loctool": "2.10.3"
+~~~
+
+
 ## 1.2.2
 * Updated fixed plugins version
 ~~~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -23,13 +23,13 @@
         "webOS"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.2.5",
-        "ilib-loctool-webos-c": "1.1.0",
-        "ilib-loctool-webos-cpp": "1.1.0",
-        "ilib-loctool-webos-javascript": "1.4.0",
-        "ilib-loctool-webos-json-resource": "1.3.4",
-        "ilib-loctool-webos-qml": "1.2.0",
-        "ilib-loctool-webos-ts-resource": "1.2.3",
-        "loctool": "2.10.2"
+        "ilib-loctool-webos-appinfo-json": "1.2.6",
+        "ilib-loctool-webos-c": "1.1.1",
+        "ilib-loctool-webos-cpp": "1.1.1",
+        "ilib-loctool-webos-javascript": "1.4.1",
+        "ilib-loctool-webos-json-resource": "1.3.5",
+        "ilib-loctool-webos-qml": "1.3.0",
+        "ilib-loctool-webos-ts-resource": "1.2.4",
+        "loctool": "2.10.3"
     }
 }


### PR DESCRIPTION
* Updated fixed loctool version to have `2.10.3`. It includes https://github.com/iLib-js/loctool/pull/137
* All plugin has updated dependent loctool version to `2.10.3` 