### PR TITLE
Release for v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.4.0
+* Updated fixed loctool and plugins version
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.2.8",
+    "ilib-loctool-webos-c": "1.1.3",
+    "ilib-loctool-webos-cpp": "1.1.3",
+    "ilib-loctool-webos-javascript": "1.4.3",
+    "ilib-loctool-webos-json-resource": "1.3.7",
+    "ilib-loctool-webos-qml": "1.3.2",
+    "ilib-loctool-webos-ts-resource": "1.2.6",
+    "loctool": "2.13.0"
+~~~
+
 ## 1.3.0
 * Updated fixed loctool and plugins version
 ~~~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -31,13 +31,13 @@
         "loctool"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.2.7",
-        "ilib-loctool-webos-c": "1.1.2",
-        "ilib-loctool-webos-cpp": "1.1.2",
-        "ilib-loctool-webos-javascript": "1.4.2",
-        "ilib-loctool-webos-json-resource": "1.3.6",
-        "ilib-loctool-webos-qml": "1.3.1",
-        "ilib-loctool-webos-ts-resource": "1.2.5",
-        "loctool": "2.12.0"
+        "ilib-loctool-webos-appinfo-json": "1.2.8",
+        "ilib-loctool-webos-c": "1.1.3",
+        "ilib-loctool-webos-cpp": "1.1.3",
+        "ilib-loctool-webos-javascript": "1.4.3",
+        "ilib-loctool-webos-json-resource": "1.3.7",
+        "ilib-loctool-webos-qml": "1.3.2",
+        "ilib-loctool-webos-ts-resource": "1.2.6",
+        "loctool": "2.13.0"
     }
 }


### PR DESCRIPTION
Updated fixed loctool and plugins version
The dependent loctool version has been updated to `2.13.0`
During a CCC preparation with loctool `2.12.0 `, The issue is found: https://github.com/iLib-js/loctool/pull/158
ReleaseNotes for loctool : https://github.com/iLib-js/loctool/blob/development/docs/ReleaseNotes.md
```
    "ilib-loctool-webos-appinfo-json": "1.2.8",
    "ilib-loctool-webos-c": "1.1.3",
    "ilib-loctool-webos-cpp": "1.1.3",
    "ilib-loctool-webos-javascript": "1.4.3",
    "ilib-loctool-webos-json-resource": "1.3.7",
    "ilib-loctool-webos-qml": "1.3.2",
    "ilib-loctool-webos-ts-resource": "1.2.6",
    "loctool": "2.13.0"
```