### PR TITLE
Release for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.5.0
+* Updated fixed loctool and plugins version
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.2.9",
+    "ilib-loctool-webos-c": "1.1.4",
+    "ilib-loctool-webos-cpp": "1.1.4",
+    "ilib-loctool-webos-javascript": "1.4.4",
+    "ilib-loctool-webos-json-resource": "1.3.8",
+    "ilib-loctool-webos-qml": "1.3.3",
+    "ilib-loctool-webos-ts-resource": "1.2.7",
+    "loctool": "2.14.1"
+~~~
+
 ## 1.4.0
 * Updated fixed loctool and plugins version
 ~~~

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -31,13 +31,13 @@
         "loctool"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.2.8",
-        "ilib-loctool-webos-c": "1.1.3",
-        "ilib-loctool-webos-cpp": "1.1.3",
-        "ilib-loctool-webos-javascript": "1.4.3",
-        "ilib-loctool-webos-json-resource": "1.3.7",
-        "ilib-loctool-webos-qml": "1.3.2",
-        "ilib-loctool-webos-ts-resource": "1.2.6",
-        "loctool": "2.13.0"
+        "ilib-loctool-webos-appinfo-json": "1.2.9",
+        "ilib-loctool-webos-c": "1.1.4",
+        "ilib-loctool-webos-cpp": "1.1.4",
+        "ilib-loctool-webos-javascript": "1.4.4",
+        "ilib-loctool-webos-json-resource": "1.3.8",
+        "ilib-loctool-webos-qml": "1.3.3",
+        "ilib-loctool-webos-ts-resource": "1.2.7",
+        "loctool": "2.14.1"
     }
 }


### PR DESCRIPTION
* Updated fixed loctool and plugins version
  * The dependent loctool version has been updated to **2.14.1**
  * According to the pseudo localization enhancement in 2.14 of loctool,  webOS plugin has been modified and updated to work properly.
  * ReleaseNotes for loctool : https://github.com/iLib-js/loctool/blob/development/docs/ReleaseNotes.md
```
    "ilib-loctool-webos-appinfo-json": "1.2.9",
    "ilib-loctool-webos-c": "1.1.4",
    "ilib-loctool-webos-cpp": "1.1.4",
    "ilib-loctool-webos-javascript": "1.4.4",
    "ilib-loctool-webos-json-resource": "1.3.8",
    "ilib-loctool-webos-qml": "1.3.3",
    "ilib-loctool-webos-ts-resource": "1.2.7",
    "loctool": "2.14.1"
```