### PR TITLE
Release for v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 1.6.0
+* Updated fixed loctool and plugins version
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.2.10",
+    "ilib-loctool-webos-c": "1.1.5",
+    "ilib-loctool-webos-cpp": "1.1.5",
+    "ilib-loctool-webos-javascript": "1.4.5",
+    "ilib-loctool-webos-json-resource": "1.3.9",
+    "ilib-loctool-webos-qml": "1.3.4",
+    "ilib-loctool-webos-ts-resource": "1.2.8",
+    "loctool": "2.16.2"
+~~~
+
 ## 1.5.0
 * Updated fixed loctool and plugins version
 ~~~

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Plugins are optimized for the webOS platform.
 # Copyright and License Information
 Unless otherwise specified, all ilib-loctool-webos-* source code files and documentation files in this repository are:
 
-Copyright (c) 2020-2021 LG Electronics
+Copyright (c) 2020-2022 LG Electronics
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.5.0",
+    "version": "1.6.0",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -31,13 +31,13 @@
         "loctool"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.2.9",
-        "ilib-loctool-webos-c": "1.1.4",
-        "ilib-loctool-webos-cpp": "1.1.4",
-        "ilib-loctool-webos-javascript": "1.4.4",
-        "ilib-loctool-webos-json-resource": "1.3.8",
-        "ilib-loctool-webos-qml": "1.3.3",
-        "ilib-loctool-webos-ts-resource": "1.2.7",
-        "loctool": "2.14.1"
+        "ilib-loctool-webos-appinfo-json": "1.2.10",
+        "ilib-loctool-webos-c": "1.1.5",
+        "ilib-loctool-webos-cpp": "1.1.5",
+        "ilib-loctool-webos-javascript": "1.4.5",
+        "ilib-loctool-webos-json-resource": "1.3.9",
+        "ilib-loctool-webos-qml": "1.3.4",
+        "ilib-loctool-webos-ts-resource": "1.2.8",
+        "loctool": "2.16.2"
     }
 }


### PR DESCRIPTION
* Updated fixed loctool and plugins version
  * The dependent loctool version has been updated to 2.16.2
  * ReleaseNotes for loctool : https://github.com/iLib-js/loctool/blob/development/docs/ReleaseNotes.md
```
    "ilib-loctool-webos-appinfo-json": "1.2.10",
    "ilib-loctool-webos-c": "1.1.5",
    "ilib-loctool-webos-cpp": "1.1.5",
    "ilib-loctool-webos-javascript": "1.454",
    "ilib-loctool-webos-json-resource": "1.3.9",
    "ilib-loctool-webos-qml": "1.3.4",
    "ilib-loctool-webos-ts-resource": "1.2.8",
    "loctool": "2.16.2"
```