### PR TITLE
Release for v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.13.1
+* Updated plugins version
+* (webos-json-resource/webos-appinfo-json) Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.
+
+
 ## 1.13.0
 * Updated plugins version
   * (webos-json-resource/webos-appinfo-json) Added a timestamp in `ilibmanifest.json` file to support wee localization.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## 1.13.1
 * Updated plugins version
 * (webos-json-resource/webos-appinfo-json) Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.
-
+~~~
+    "ilib-loctool-webos-appinfo-json": "1.6.1",
+    "ilib-loctool-webos-c": "1.5.2",
+    "ilib-loctool-webos-cpp": "1.5.2",
+    "ilib-loctool-webos-javascript": "1.8.2",
+    "ilib-loctool-webos-json-resource": "1.5.1",
+    "ilib-loctool-webos-qml": "1.5.1",
+    "ilib-loctool-webos-ts-resource": "1.4.1",
+    "loctool": "2.20.2"
+~~~
 
 ## 1.13.0
 * Updated plugins version

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
         "loctool"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.6.0",
-        "ilib-loctool-webos-c": "1.5.1",
-        "ilib-loctool-webos-cpp": "1.5.1",
-        "ilib-loctool-webos-javascript": "1.8.1",
-        "ilib-loctool-webos-json-resource": "1.5.0",
+        "ilib-loctool-webos-appinfo-json": "1.6.1",
+        "ilib-loctool-webos-c": "1.5.2",
+        "ilib-loctool-webos-cpp": "1.5.2",
+        "ilib-loctool-webos-javascript": "1.8.2",
+        "ilib-loctool-webos-json-resource": "1.5.1",
         "ilib-loctool-webos-qml": "1.5.1",
         "ilib-loctool-webos-ts-resource": "1.4.1",
         "loctool": "2.20.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {


### PR DESCRIPTION
* Updated plugins version
  * webos-json-resource/webos-appinfo-json
       * Fixed to generate `ilibmanifest.json` file correctly even when a dummy file exists.
```
    "ilib-loctool-webos-appinfo-json": "1.6.1",
    "ilib-loctool-webos-c": "1.5.2",
    "ilib-loctool-webos-cpp": "1.5.2",
    "ilib-loctool-webos-javascript": "1.8.2",
    "ilib-loctool-webos-json-resource": "1.5.1",
    "ilib-loctool-webos-qml": "1.5.1",
    "ilib-loctool-webos-ts-resource": "1.4.1",
    "loctool": "2.20.2"
```