### PR TITLE
Release for v1.14.1 (Update to have fixed version on webos-json plugin )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 1.14.1
+* Update to have fixed verion on ilib-loctool-webos-json plugin.
+ * All of plugin has to have a fixed versoin for webOS distsribution.
+~~~
+  "ilib-loctool-webos-appinfo-json": "1.7.0",
+  "ilib-loctool-webos-c": "1.6.0",
+  "ilib-loctool-webos-cpp": "1.6.0",
+  "ilib-loctool-webos-javascript": "1.9.0",
+  "ilib-loctool-webos-json": "1.0.0",
+  "ilib-loctool-webos-json-resource": "1.5.2",
+  "ilib-loctool-webos-qml": "1.6.0",
+  "ilib-loctool-webos-ts-resource": "1.4.2",
+  "loctool": "2.21.0"
+~~~
+
 ## 1.15.0
 * Updated fixed loctool and plugins version
 * **loctool**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.15.0",
+    "version": "1.14.1",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -32,13 +32,13 @@
     ],
     "dependencies": {
         "ilib-loctool-webos-appinfo-json": "1.7.0",
-        "ilib-loctool-webos-c": "1.7.0",
-        "ilib-loctool-webos-cpp": "1.7.0",
-        "ilib-loctool-webos-javascript": "1.10.0",
-        "ilib-loctool-webos-json": "^1.1.0",
-        "ilib-loctool-webos-json-resource": "1.5.3",
-        "ilib-loctool-webos-qml": "1.7.0",
-        "ilib-loctool-webos-ts-resource": "1.5.0",
-        "loctool": "2.22.0"
+        "ilib-loctool-webos-c": "1.6.0",
+        "ilib-loctool-webos-cpp": "1.6.0",
+        "ilib-loctool-webos-javascript": "1.9.0",
+        "ilib-loctool-webos-json": "1.0.0",
+        "ilib-loctool-webos-json-resource": "1.5.2",
+        "ilib-loctool-webos-qml": "1.6.0",
+        "ilib-loctool-webos-ts-resource": "1.4.2",
+        "loctool": "2.21.0"
     }
 }


### PR DESCRIPTION
* Downgrad webos plugin version for v1.14.1. version release.
* All of package version has to have a fixed version. but I put the carrot version regarding `ilib-loctool-webos-json`plugin which should not be happens in webOS.
* I'm going to release v1.14.1 and will release again for v1.15.0