### PR TITLE
Release for v1.15.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,6 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:12.13
-      - test:
-          docker_image: cimg/node:14.21
-      - test:
           docker_image: cimg/node:16.20
       - test:
           docker_image: cimg/node:18.15

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,9 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: circleci/node:10-browsers
+          docker_image: cimg/node:14.21
       - test:
-          docker_image: circleci/node:12-browsers
+          docker_image: cimg/node:16.19
       - test:
-          docker_image: circleci/node:13-browsers
-      - test:
-          docker_image: circleci/node:14-browsers
-      - test:
-          docker_image: circleci/node:16-browsers
+          docker_image: cimg/node:18.15
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,11 +22,11 @@ workflows:
       - test:
           docker_image: circleci/node:10-browsers
       - test:
-          docker_image: circleci/node:12-browsers
+          docker_image: cimg/node:12.13
       - test:
-          docker_image: circleci/node:13-browsers
+          docker_image: cimg/node:14.21
       - test:
-          docker_image: circleci/node:14-browsers
+          docker_image: cimg/node:16.19
       - test:
-          docker_image: circleci/node:16-browsers
+          docker_image: cimg/node:18.15
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
           name: Setup
           command: |
             rm -rf node_modules package-lock.json
+            npm -v
+            node -v
             npm install
             
 workflows:
@@ -20,7 +22,11 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:16.20.2
+          docker_image: cimg/node:12.13
+      - test:
+          docker_image: cimg/node:14.21
+      - test:
+          docker_image: cimg/node:16.20
       - test:
           docker_image: cimg/node:18.15
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Setup
           command: |
-            rm -rf node_modules package-lock.json
+            rm -rf node_modules
             npm install
             
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ workflows:
       - test:
           docker_image: cimg/node:14.21
       - test:
-          docker_image: cimg/node:16.19
+          docker_image: cimg/node:16.20.2
       - test:
           docker_image: cimg/node:18.15
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Setup
           command: |
-            rm -rf node_modules
+            rm -rf node_modules package-lock.json
             npm install
             
 workflows:
@@ -22,11 +22,11 @@ workflows:
       - test:
           docker_image: circleci/node:10-browsers
       - test:
-          docker_image: cimg/node:12.13
+          docker_image: circleci/node:12-browsers
       - test:
-          docker_image: cimg/node:14.21
+          docker_image: circleci/node:13-browsers
       - test:
-          docker_image: cimg/node:16.19
+          docker_image: circleci/node:14-browsers
       - test:
-          docker_image: cimg/node:18.15
+          docker_image: circleci/node:16-browsers
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,6 @@ workflows:
   test-all-node-versions:
     jobs:
       - test:
-          docker_image: cimg/node:14.21
-      - test:
           docker_image: cimg/node:16.20.2
       - test:
           docker_image: cimg/node:18.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.15.2
+* Updated fixed loctool and plugins version
+* **loctool**
+  * changed the zxx-Hans-XX pseudo style name to `debug-han-simplified`.
+* **Fixes in plugins**
+  * Update to be included `npm-shrinkwrap.json` in the published files.
+~~~
+  "ilib-loctool-webos-appinfo-json": "1.7.1",
+  "ilib-loctool-webos-c": "1.7.1",
+  "ilib-loctool-webos-cpp": "1.7.1",
+  "ilib-loctool-webos-javascript": "1.10.1",
+  "ilib-loctool-webos-json": "1.1.2",
+  "ilib-loctool-webos-json-resource": "1.5.4",
+  "ilib-loctool-webos-qml": "1.7.1",
+  "ilib-loctool-webos-ts-resource": "1.5.1",
+  "loctool": "2.23.1"
+~~~
+
 ## 1.15.1
 * Updated fixed loctool and plugins version
 * **Fixes in plugins**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-webos-dist",
-    "version": "1.15.1",
+    "version": "1.15.2",
     "description": "Full-featured build environment for webOS localization",
     "main": "index.js",
     "repository": {
@@ -31,14 +31,14 @@
         "loctool"
     ],
     "dependencies": {
-        "ilib-loctool-webos-appinfo-json": "1.7.0",
-        "ilib-loctool-webos-c": "1.7.0",
-        "ilib-loctool-webos-cpp": "1.7.0",
-        "ilib-loctool-webos-javascript": "1.10.0",
-        "ilib-loctool-webos-json": "1.1.1",
-        "ilib-loctool-webos-json-resource": "1.5.3",
-        "ilib-loctool-webos-qml": "1.7.0",
-        "ilib-loctool-webos-ts-resource": "1.5.0",
-        "loctool": "2.22.0"
+        "ilib-loctool-webos-appinfo-json": "1.7.1",
+        "ilib-loctool-webos-c": "1.7.1",
+        "ilib-loctool-webos-cpp": "1.7.1",
+        "ilib-loctool-webos-javascript": "1.10.1",
+        "ilib-loctool-webos-json": "1.1.2",
+        "ilib-loctool-webos-json-resource": "1.5.4",
+        "ilib-loctool-webos-qml": "1.7.1",
+        "ilib-loctool-webos-ts-resource": "1.5.1",
+        "loctool": "2.23.1"
     }
 }


### PR DESCRIPTION
* Added `npm-shrinkwrap.json` file. This main branch is directly checked out for webOS build. so I think it's better to maintain `npm-shrinkwrap.json` file here just in case.
* Remove circleCI test for node v10, 12. 14 The current node version of webOS is v16.20.2

* Updated fixed loctool and plugins version
* **loctool**
  * changed the zxx-Hans-XX pseudo style name to `debug-han-simplified`.
* **Fixes in plugins**
  * Update to be included `npm-shrinkwrap.json` in the published files.
~~~
  "ilib-loctool-webos-appinfo-json": "1.7.1",
  "ilib-loctool-webos-c": "1.7.1",
  "ilib-loctool-webos-cpp": "1.7.1",
  "ilib-loctool-webos-javascript": "1.10.1",
  "ilib-loctool-webos-json": "1.1.2",
  "ilib-loctool-webos-json-resource": "1.5.4",
  "ilib-loctool-webos-qml": "1.7.1",
  "ilib-loctool-webos-ts-resource": "1.5.1",
  "loctool": "2.23.1"
~~~