### PR TITLE
Update to run node v20 on circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,4 +25,6 @@ workflows:
           docker_image: cimg/node:16.20
       - test:
           docker_image: cimg/node:18.15
+      - test:
+          docker_image: cimg/node:20.18
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
       - test:
           docker_image: cimg/node:16.20
       - test:
-          docker_image: cimg/node:18.15
+          docker_image: cimg/node:18.20
       - test:
           docker_image: cimg/node:20.18
       - test


### PR DESCRIPTION
- Update to run test node v20 on circleCI
- Update node v18's minor version as latest